### PR TITLE
Return 403 for invalid API keys, unify API error format, add exception handler, tests and docs

### DIFF
--- a/docs/admin-manual-de.md
+++ b/docs/admin-manual-de.md
@@ -139,12 +139,35 @@ Das Rest-API verwendet folgende Befehle (Verben), Header und Statuscodes. Insbes
 
 - 200
 - 202
+- 400
 - 401
 - 403
+- 500
 
 ### Varia
 
 - Dateigrössen bis 200 MB müssen hochgeladen werden können.
+
+### Fehlerformat
+
+Fehlerantworten werden als JSON mit folgendem gemeinsamen Format ausgeliefert:
+
+```
+{
+  "code": "ch.so.agi.datahub.controller.ApiKeyController",
+  "message": "API key not deleted.",
+  "timestamp": "2024-04-11T06:24:56.218306Z",
+  "path": "/api/keys/5b4fd340-adbb-441a-b9c3-e1d2f13cb1e0",
+  "details": [
+    {
+      "field": "organisation",
+      "message": "must not be blank"
+    }
+  ]
+}
+```
+
+`path` und `details` sind optional. `details` wird hauptsächlich für Validierungsfehler (Statuscode `400`) genutzt.
 
 ## Cluster
 
@@ -168,4 +191,3 @@ Auf dem Endpunkt `/datahub`ist ein read-only Directory Listing vorhanden.
 ## Konfiguration GDI
 
 Siehe [sogis/doc](https://github.com/sogis/dok/blob/dok/dok_funktionale_einheiten/Documents/datahub/datahub.md)
-

--- a/docs/develop-manual-de.md
+++ b/docs/develop-manual-de.md
@@ -20,6 +20,22 @@ Das Frontend (die Jobübersicht) ist mit Jakarta Faces umgesetzt (Joinfaces und 
 
 ## Entwicklung
 
+### Tests
+
+Standard-Testlauf:
+
+```
+./gradlew test
+```
+
+Hinweis: Der `DatahubApplicationTests`-Kontexttest benötigt eine erreichbare PostgreSQL-DB (u.a. für Jobrunr). Ohne DB schlägt der Test mit einer Connection-Exception fehl.
+
+Folgende fokussierte Tests wurden ohne DB erfolgreich ausgeführt (z.B. für Fehlerantworten in Controllern/Filtern):
+
+```
+./gradlew test --tests ch.so.agi.datahub.controller.DeliveryControllerTest --tests ch.so.agi.datahub.controller.ApiKeyControllerTest --tests ch.so.agi.datahub.auth.DeliveryAuthorizationFilterTest --tests ch.so.agi.datahub.auth.RevokeApiKeyFilterTest
+```
+
 ### Datenbank
 
 Es müssen mit _ili2pg_ das Autorisierungsschema und das Logschema erstellt werden. Siehe dazu Betriebshandbuch. Die Tabellen für Jobrunr werden bei genügender Berechtigung des Datenbankusers und beim Setzen der Konfiguration `org.jobrunr.database.skip-create` resp. `JOBRUNR_SKIP_CREATE` auf `false` beim Starten der Anwendung selbständig erstellt. Das Schema muss jedoch bereits vorhanden sein. Erstmalig muss es manuell erstellt werden:
@@ -144,5 +160,4 @@ curl -i -X GET --header "X-API-KEY:b1025370-7fa1-4195-bf03-2a48be85450c" http://
 curl -i -X POST --header "X-API-KEY:b1025370-7fa1-4195-bf03-2a48be85450c" -F 'file=@src/test/data/DMAV_Dienstbarkeitsgrenzen_V1_0.449.xtf' -F 'theme=DMAV_Dienstbarkeitsgrenzen_V1_0' -F 'operat=449' http://localhost:8080/api/deliveries
 ```
  
-
 

--- a/docs/user-manual-de.md
+++ b/docs/user-manual-de.md
@@ -81,9 +81,11 @@ Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
 Content-Type: application/json
-Content-Length: 0
+Transfer-Encoding: chunked
 Date: Thu, 11 Apr 2024 05:45:22 GMT
 Connection: close
+
+{"code":"ch.so.agi.datahub.auth.ApiKeyHeaderAuthenticationFilter","message":"Did not find api key header in request.","timestamp":"2024-04-11T05:45:22.463Z","path":"/api/deliveries"}
 ```
 
 (2) Wird ein falscher API-Key verwendet, antwortet der Server mit dem Statuscode `403` und mit folgendem Inhalt:
@@ -100,7 +102,7 @@ Content-Type: application/json
 Transfer-Encoding: chunked
 Date: Thu, 11 Apr 2024 06:06:20 GMT
 
-{"timestamp":"2024-04-11T06:06:20.463+00:00","status":403,"error":"Forbidden","message":"Forbidden","path":"/api/deliveries"}
+{"code":"ch.so.agi.datahub.auth.ApiKeyHeaderAuthenticationFilter","message":"Forbidden.","timestamp":"2024-04-11T06:06:20.463Z","path":"/api/deliveries"}
 ```
 
 (3) Falls ein API-Key verwendet wird, der existiert, dessen Organisation aber nicht für Lieferung des Operates autorisiert ist, antwortet der Server ebenfalls mit dem Statuscode `403` und diese Inhalt:
@@ -117,7 +119,7 @@ Content-Type: application/json
 Content-Length: 138
 Date: Thu, 11 Apr 2024 06:07:25 GMT
 
-{"code":"ch.so.agi.datahub.auth.DeliveryAuthorizationFilter","message":"User is not authorized","timestamp":"2024-04-11T06:07:25.143747Z"}
+{"code":"ch.so.agi.datahub.auth.DeliveryAuthorizationFilter","message":"User is not authorized","timestamp":"2024-04-11T06:07:25.143747Z","path":"/api/deliveries"}
 ```
 
 ## API-Keys anfordern und löschen
@@ -196,7 +198,7 @@ Transfer-Encoding: chunked
 Date: Thu, 11 Apr 2024 06:24:56 GMT
 Connection: close
 
-{"code":"ch.so.agi.datahub.controller.ApiKeyController","message":"API key not deleted.","timestamp":"2024-04-11T06:24:56.218306Z"}
+{"code":"ch.so.agi.datahub.controller.ApiKeyController","message":"API key not deleted.","timestamp":"2024-04-11T06:24:56.218306Z","path":"/api/keys/5b4fd340-adbb-441a-b9c3-e1d2f13cb1e0"}
 ```
 
 Zukünftig werden API-Keys immer ein Ablaufdatum haben und es müssen regelmässig neue Keys angefordert werden.

--- a/src/main/java/ch/so/agi/datahub/auth/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/ch/so/agi/datahub/auth/CustomAuthenticationEntryPoint.java
@@ -2,10 +2,8 @@ package ch.so.agi.datahub.auth;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -13,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import ch.so.agi.datahub.model.GenericResponse;
+import ch.so.agi.datahub.model.ApiError;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
@@ -31,7 +29,8 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         ServletOutputStream responseStream = response.getOutputStream();
-        mapper.writeValue(responseStream, new GenericResponse(authException.getClass().getCanonicalName(), authException.getMessage(), Instant.now()));
+        mapper.writeValue(responseStream, new ApiError(authException.getClass().getCanonicalName(), authException.getMessage(),
+                Instant.now(), request.getRequestURI(), null));
         responseStream.flush();
     }
 }

--- a/src/main/java/ch/so/agi/datahub/auth/DeliveryAuthorizationFilter.java
+++ b/src/main/java/ch/so/agi/datahub/auth/DeliveryAuthorizationFilter.java
@@ -20,7 +20,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ch.so.agi.datahub.AppConstants;
-import ch.so.agi.datahub.model.GenericResponse;
+import ch.so.agi.datahub.model.ApiError;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
@@ -59,7 +59,8 @@ public class DeliveryAuthorizationFilter extends OncePerRequestFilter {
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             ServletOutputStream responseStream = response.getOutputStream();
-            mapper.writeValue(responseStream, new GenericResponse(this.getClass().getCanonicalName(), "Missing parameter", Instant.now()));
+            mapper.writeValue(responseStream, new ApiError(this.getClass().getCanonicalName(), "Missing parameter", Instant.now(),
+                    request.getRequestURI(), null));
             responseStream.flush();
             return;
         }
@@ -114,7 +115,8 @@ WHERE
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             ServletOutputStream responseStream = response.getOutputStream();
-            mapper.writeValue(responseStream, new GenericResponse(this.getClass().getCanonicalName(), "User is not authorized", Instant.now()));
+            mapper.writeValue(responseStream, new ApiError(this.getClass().getCanonicalName(), "User is not authorized", Instant.now(),
+                    request.getRequestURI(), null));
             responseStream.flush();
         } else {
             request.setAttribute(AppConstants.ATTRIBUTE_OPERAT_DELIVERY_INFO, result);

--- a/src/main/java/ch/so/agi/datahub/auth/RevokeApiKeyFilter.java
+++ b/src/main/java/ch/so/agi/datahub/auth/RevokeApiKeyFilter.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ch.so.agi.datahub.cayenne.CoreApikey;
 import ch.so.agi.datahub.cayenne.CoreOrganisation;
-import ch.so.agi.datahub.model.GenericResponse;
+import ch.so.agi.datahub.model.ApiError;
 import ch.so.agi.datahub.service.EmailService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -102,8 +102,8 @@ public class RevokeApiKeyFilter extends OncePerRequestFilter {
                 response.setContentType(MediaType.APPLICATION_JSON_VALUE);
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 ServletOutputStream responseStream = response.getOutputStream();
-                mapper.writeValue(responseStream, new GenericResponse(this.getClass().getCanonicalName(),
-                        "Possible API key was revoked.", Instant.now()));
+                mapper.writeValue(responseStream, new ApiError(this.getClass().getCanonicalName(),
+                        "Possible API key was revoked.", Instant.now(), request.getRequestURI(), null));
                 responseStream.flush();
                 return;
             }            

--- a/src/main/java/ch/so/agi/datahub/auth/WebSecurityConfig.java
+++ b/src/main/java/ch/so/agi/datahub/auth/WebSecurityConfig.java
@@ -112,7 +112,7 @@ public class WebSecurityConfig {
                         //.requestMatchers(AntPathRequestMatcher.antMatcher("/public/**")).permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new ApiKeyHeaderAuthenticationFilter(authenticationManager(), apiKeyHeaderName), LogoutFilter.class)
+                .addFilterBefore(new ApiKeyHeaderAuthenticationFilter(authenticationManager(), apiKeyHeaderName, mapper), LogoutFilter.class)
                 // TODO
 //                .exceptionHandling(exceptionHandling ->
 //                    exceptionHandling.authenticationEntryPoint(authEntryPoint)

--- a/src/main/java/ch/so/agi/datahub/controller/ApiExceptionHandler.java
+++ b/src/main/java/ch/so/agi/datahub/controller/ApiExceptionHandler.java
@@ -1,0 +1,64 @@
+package ch.so.agi.datahub.controller;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import ch.so.agi.datahub.model.ApiError;
+import ch.so.agi.datahub.model.ApiErrorDetail;
+import jakarta.servlet.http.HttpServletRequest;
+
+@ControllerAdvice
+public class ApiExceptionHandler {
+    private static final Logger logger = LoggerFactory.getLogger(ApiExceptionHandler.class);
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiError> handleValidationException(MethodArgumentNotValidException exception, HttpServletRequest request) {
+        List<ApiErrorDetail> details = exception.getBindingResult().getFieldErrors().stream()
+                .map(this::toDetail)
+                .toList();
+        ApiError error = new ApiError(
+                exception.getClass().getCanonicalName(),
+                "Validation failed.",
+                Instant.now(),
+                request.getRequestURI(),
+                details);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiError> handleNotReadable(HttpMessageNotReadableException exception, HttpServletRequest request) {
+        ApiError error = new ApiError(
+                exception.getClass().getCanonicalName(),
+                "Request body is not readable.",
+                Instant.now(),
+                request.getRequestURI(),
+                null);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    @ExceptionHandler({Exception.class, RuntimeException.class})
+    public ResponseEntity<ApiError> handleUnhandled(Exception exception, HttpServletRequest request) {
+        logger.error("Unhandled exception", exception);
+        ApiError error = new ApiError(
+                exception.getClass().getCanonicalName(),
+                "Please contact service provider.",
+                Instant.now(),
+                request.getRequestURI(),
+                null);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+
+    private ApiErrorDetail toDetail(FieldError error) {
+        return new ApiErrorDetail(error.getField(), error.getDefaultMessage());
+    }
+}

--- a/src/main/java/ch/so/agi/datahub/controller/DeliveryController.java
+++ b/src/main/java/ch/so/agi/datahub/controller/DeliveryController.java
@@ -1,5 +1,6 @@
 package ch.so.agi.datahub.controller;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -22,6 +23,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import ch.so.agi.datahub.AppConstants;
 import ch.so.agi.datahub.cayenne.DeliveriesDelivery;
+import ch.so.agi.datahub.model.ApiError;
 import ch.so.agi.datahub.service.DeliveryService;
 import ch.so.agi.datahub.service.FilesStorageService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -109,12 +111,18 @@ public class DeliveryController {
     }
     
     @ExceptionHandler({Exception.class, RuntimeException.class})
-    public ResponseEntity<?> error(Exception e) {
+    public ResponseEntity<?> error(Exception e, HttpServletRequest request) {
         e.printStackTrace();
         logger.error("<{}>", e.getMessage());
+        ApiError error = new ApiError(
+                e.getClass().getCanonicalName(),
+                "Please contact service provider. Delivery is not queued.",
+                Instant.now(),
+                request.getRequestURI(),
+                null);
         return ResponseEntity
                 .internalServerError()
-                .body("Please contact service provider. Delivery is not queued.");
+                .body(error);
     }
     
     private String getHost() {

--- a/src/main/java/ch/so/agi/datahub/model/ApiError.java
+++ b/src/main/java/ch/so/agi/datahub/model/ApiError.java
@@ -1,0 +1,15 @@
+package ch.so.agi.datahub.model;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonSerialize
+public record ApiError(String code, String message, Instant timestamp, String path, List<ApiErrorDetail> details) {
+
+}

--- a/src/main/java/ch/so/agi/datahub/model/ApiErrorDetail.java
+++ b/src/main/java/ch/so/agi/datahub/model/ApiErrorDetail.java
@@ -1,0 +1,12 @@
+package ch.so.agi.datahub.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonSerialize
+public record ApiErrorDetail(String field, String message) {
+
+}

--- a/src/test/java/ch/so/agi/datahub/auth/DeliveryAuthorizationFilterTest.java
+++ b/src/test/java/ch/so/agi/datahub/auth/DeliveryAuthorizationFilterTest.java
@@ -1,0 +1,39 @@
+package ch.so.agi.datahub.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.cayenne.ObjectContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.FilterChain;
+
+class DeliveryAuthorizationFilterTest {
+
+    @Test
+    void missingParametersReturnsApiError() throws Exception {
+        ObjectContext objectContext = mock(ObjectContext.class);
+        ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        DeliveryAuthorizationFilter filter = new DeliveryAuthorizationFilter(objectContext, null, mapper);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/deliveries");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+        var json = mapper.readTree(response.getContentAsString(StandardCharsets.UTF_8));
+        assertThat(json.get("message").asText()).isEqualTo("Missing parameter");
+        assertThat(json.get("path").asText()).isEqualTo("/api/deliveries");
+        assertThat(json.get("timestamp").asText()).isNotBlank();
+    }
+}

--- a/src/test/java/ch/so/agi/datahub/auth/RevokeApiKeyFilterTest.java
+++ b/src/test/java/ch/so/agi/datahub/auth/RevokeApiKeyFilterTest.java
@@ -1,0 +1,62 @@
+package ch.so.agi.datahub.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.ResourceBundle;
+
+import org.apache.cayenne.ObjectContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ch.so.agi.datahub.service.EmailService;
+import jakarta.servlet.FilterChain;
+
+class RevokeApiKeyFilterTest {
+
+    @Test
+    void httpRequestRevokesAndReturnsApiError() throws Exception {
+        ObjectContext objectContext = mock(ObjectContext.class);
+        when(objectContext.select(any())).thenReturn(List.of());
+        PasswordEncoder encoder = mock(PasswordEncoder.class);
+        EmailService emailService = mock(EmailService.class);
+        ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        ResourceBundle resourceBundle = mock(ResourceBundle.class);
+
+        RevokeApiKeyFilter filter = new RevokeApiKeyFilter("X-API-KEY", objectContext, encoder,
+                emailService, mapper, new String[] { "localhost" }, resourceBundle);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/keys/revoke");
+        request.setScheme("http");
+        request.setServerName("example.com");
+        request.addHeader("X-API-KEY", "test-key");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        ServletRequestAttributes attributes = new ServletRequestAttributes(request);
+        RequestContextHolder.setRequestAttributes(attributes);
+        try {
+            filter.doFilterInternal(request, response, chain);
+        } finally {
+            RequestContextHolder.resetRequestAttributes();
+        }
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+        var json = mapper.readTree(response.getContentAsString(StandardCharsets.UTF_8));
+        assertThat(json.get("message").asText()).isEqualTo("Possible API key was revoked.");
+        assertThat(json.get("path").asText()).isEqualTo("/api/keys/revoke");
+        assertThat(json.get("timestamp").asText()).isNotBlank();
+    }
+}

--- a/src/test/java/ch/so/agi/datahub/controller/ApiKeyControllerTest.java
+++ b/src/test/java/ch/so/agi/datahub/controller/ApiKeyControllerTest.java
@@ -1,0 +1,49 @@
+package ch.so.agi.datahub.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doReturn;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.ResourceBundle;
+
+import org.apache.cayenne.ObjectContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.core.GrantedAuthority;
+
+import ch.so.agi.datahub.AppConstants;
+import ch.so.agi.datahub.model.ApiError;
+import ch.so.agi.datahub.service.EmailService;
+
+class ApiKeyControllerTest {
+
+    @Test
+    void createApiKeyMissingOrganisationReturnsApiError() {
+        ObjectContext objectContext = mock(ObjectContext.class);
+        PasswordEncoder encoder = mock(PasswordEncoder.class);
+        EmailService emailService = mock(EmailService.class);
+        ResourceBundle resourceBundle = mock(ResourceBundle.class);
+
+        ApiKeyController controller = new ApiKeyController(objectContext, encoder, emailService, resourceBundle);
+
+        Authentication authentication = mock(Authentication.class);
+        Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(AppConstants.ROLE_NAME_ADMIN));
+        doReturn(authorities).when(authentication).getAuthorities();
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/keys");
+        ResponseEntity<?> response = controller.createApiKey(authentication, null, request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(500);
+        assertThat(response.getBody()).isInstanceOf(ApiError.class);
+        ApiError error = (ApiError) response.getBody();
+        assertThat(error.message()).isEqualTo("Parameter 'organisation' is required.");
+        assertThat(error.path()).isEqualTo("/api/keys");
+        assertThat(error.timestamp()).isNotNull();
+    }
+}

--- a/src/test/java/ch/so/agi/datahub/controller/DeliveryControllerTest.java
+++ b/src/test/java/ch/so/agi/datahub/controller/DeliveryControllerTest.java
@@ -1,0 +1,38 @@
+package ch.so.agi.datahub.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.apache.cayenne.ObjectContext;
+import org.jobrunr.scheduling.JobScheduler;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import ch.so.agi.datahub.model.ApiError;
+import ch.so.agi.datahub.service.DeliveryService;
+import ch.so.agi.datahub.service.FilesStorageService;
+
+class DeliveryControllerTest {
+
+    @Test
+    void errorReturnsApiError() {
+        DeliveryController controller = new DeliveryController(
+                mock(PasswordEncoder.class),
+                mock(JobScheduler.class),
+                mock(DeliveryService.class),
+                mock(ObjectContext.class),
+                mock(FilesStorageService.class));
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/deliveries");
+        ResponseEntity<?> response = controller.error(new RuntimeException("boom"), request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(500);
+        assertThat(response.getBody()).isInstanceOf(ApiError.class);
+        ApiError error = (ApiError) response.getBody();
+        assertThat(error.message()).isEqualTo("Please contact service provider. Delivery is not queued.");
+        assertThat(error.path()).isEqualTo("/api/deliveries");
+        assertThat(error.timestamp()).isNotNull();
+    }
+}


### PR DESCRIPTION
### Motivation

- Restore the distinction between authentication and authorization by returning `403 Forbidden` for invalid API keys while keeping `401` for missing credentials. 
- Provide a consistent JSON error payload across controllers and filters to make error handling and client consumption uniform. 
- Document how to run tests and which tests can be executed without a DB, and add focused unit tests for filters/controllers.

### Description

- Introduced `ApiError` and `ApiErrorDetail` records and replaced multiple ad-hoc error responses with this unified JSON format. 
- Added `ApiExceptionHandler` (`@ControllerAdvice`) to translate common exceptions into `ApiError` responses (`400` and `500` handling). 
- Updated authentication/authorization path: `ApiKeyHeaderAuthenticationFilter` now writes `ApiError` JSON and sets `401` for missing header and `403` for invalid key; `DeliveryAuthorizationFilter`, `RevokeApiKeyFilter`, `CustomAuthenticationEntryPoint`, `ApiKeyController` and `DeliveryController` were adapted to return `ApiError` and include request `path` where applicable. 
- Wired `ObjectMapper` into security filter (`WebSecurityConfig`) and added unit tests for the updated behavior (`DeliveryAuthorizationFilterTest`, `RevokeApiKeyFilterTest`, `ApiKeyControllerTest`, `DeliveryControllerTest`) and updated user/admin/developer docs (`user-manual-de.md`, `admin-manual-de.md`, `develop-manual-de.md`) to describe the new error format and test commands.

### Testing

- Executed the full test suite with `./gradlew test`, which ran 5 tests and failed with 1 failing test; the failure is a context startup error in `DatahubApplicationTests` caused by a missing PostgreSQL database connection (Jobrunr requires a reachable DB). 
- A focused test command to run unit tests that do not require a DB is added to the developer manual: `./gradlew test --tests ch.so.agi.datahub.controller.DeliveryControllerTest --tests ch.so.agi.datahub.controller.ApiKeyControllerTest --tests ch.so.agi.datahub.auth.DeliveryAuthorizationFilterTest --tests ch.so.agi.datahub.auth.RevokeApiKeyFilterTest` (these tests are intended to run without an external DB).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e4d0624108328a42f5f6a13ce50f6)