### PR TITLE
Return ApiError JSON for auth failures (401/403)

### DIFF
--- a/src/main/java/ch/so/agi/datahub/auth/ApiErrorAccessDeniedHandler.java
+++ b/src/main/java/ch/so/agi/datahub/auth/ApiErrorAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package ch.so.agi.datahub.auth;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ch.so.agi.datahub.model.ApiError;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class ApiErrorAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper mapper;
+
+    public ApiErrorAccessDeniedHandler(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+            AccessDeniedException accessDeniedException) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        ServletOutputStream responseStream = response.getOutputStream();
+        mapper.writeValue(responseStream, new ApiError(accessDeniedException.getClass().getCanonicalName(),
+                accessDeniedException.getMessage(), Instant.now(), request.getRequestURI(), null));
+        responseStream.flush();
+    }
+}

--- a/src/main/java/ch/so/agi/datahub/auth/ApiErrorAuthenticationEntryPoint.java
+++ b/src/main/java/ch/so/agi/datahub/auth/ApiErrorAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package ch.so.agi.datahub.auth;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ch.so.agi.datahub.model.ApiError;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class ApiErrorAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper mapper;
+
+    public ApiErrorAuthenticationEntryPoint(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException authException) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        ServletOutputStream responseStream = response.getOutputStream();
+        mapper.writeValue(responseStream, new ApiError(authException.getClass().getCanonicalName(),
+                authException.getMessage(), Instant.now(), request.getRequestURI(), null));
+        responseStream.flush();
+    }
+}

--- a/src/test/java/ch/so/agi/datahub/auth/ApiKeySecurityTest.java
+++ b/src/test/java/ch/so/agi/datahub/auth/ApiKeySecurityTest.java
@@ -1,0 +1,95 @@
+package ch.so.agi.datahub.auth;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ResourceBundle;
+
+import javax.sql.DataSource;
+
+import org.apache.cayenne.ObjectContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import ch.so.agi.datahub.service.EmailService;
+
+@WebMvcTest(controllers = ApiKeySecurityTest.TestController.class)
+@Import({WebSecurityConfig.class, ApiErrorAuthenticationEntryPoint.class, ApiErrorAccessDeniedHandler.class})
+@TestPropertySource(properties = {
+        "app.apiKeyHeaderName=X-API-KEY",
+        "app.httpWhitelist=localhost",
+        "app.adminAccountInit=false",
+        "app.createDirectories=false"
+})
+class ApiKeySecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ObjectContext objectContext;
+
+    @MockBean
+    private DataSource dataSource;
+
+    @MockBean
+    private PasswordEncoder passwordEncoder;
+
+    @MockBean
+    private EmailService emailService;
+
+    @MockBean
+    private ResourceBundle resourceBundle;
+
+    @MockBean
+    private ApiKeyHeaderAuthenticationService apiKeyHeaderAuthenticationService;
+
+    @Test
+    void missingApiKeyUsesApiErrorAuthenticationEntryPoint() throws Exception {
+        mockMvc.perform(get("/api/keys/test"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(jsonPath("$.message").value("Did not find api key header in request."))
+                .andExpect(jsonPath("$.path").value("/api/keys/test"))
+                .andExpect(jsonPath("$.timestamp").isNotEmpty());
+    }
+
+    @Test
+    void invalidApiKeyUsesApiErrorAccessDeniedHandler() throws Exception {
+        when(apiKeyHeaderAuthenticationService.authenticate(any(ApiKeyHeaderAuthenticationToken.class)))
+                .thenReturn(new ApiKeyHeaderAuthenticationToken("invalid"));
+
+        mockMvc.perform(get("/api/keys/test")
+                .header("X-API-KEY", "invalid")
+                .with(request -> {
+                    request.setServerName("localhost");
+                    return request;
+                }))
+                .andExpect(status().isForbidden())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(jsonPath("$.message").value("Forbidden."))
+                .andExpect(jsonPath("$.path").value("/api/keys/test"))
+                .andExpect(jsonPath("$.timestamp").isNotEmpty());
+    }
+
+    @RestController
+    static class TestController {
+        @GetMapping("/api/keys/test")
+        String test() {
+            return "ok";
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure authentication and authorization failures return the project's `ApiError` JSON shape instead of default/error HTML so clients get a consistent error format for 401 and 403 responses.
- Make the 403 case for invalid API keys go through a dedicated `AccessDeniedHandler` so the existing standard error JSON is replaced by `ApiError`.

### Description
- Add `ApiErrorAuthenticationEntryPoint` to write `ApiError` as JSON for 401 responses using the injected `ObjectMapper` and `Content-Type: application/json`.
- Add `ApiErrorAccessDeniedHandler` to write `ApiError` as JSON for 403 responses using the injected `ObjectMapper` and `Content-Type: application/json`.
- Update `ApiKeyHeaderAuthenticationFilter` to delegate missing-key (401) and invalid-key/failed-auth (403) situations to the new entry point and access-denied handler instead of writing custom JSON directly.
- Register and wire both handlers in `WebSecurityConfig` into the `SecurityFilterChain` via `.exceptionHandling(...)` and pass them into the API key filter; add `ApiKeySecurityTest` to assert the `ApiError` format for missing/invalid API keys and adjust the test setup (`@MockBean DataSource` and disabling app init flags) to avoid application bootstrap side effects during the slice test.

### Testing
- Ran the focused test: `./gradlew test --tests ch.so.agi.datahub.auth.ApiKeySecurityTest` and it completed successfully (tests passed).
- The changes were verified by the new `ApiKeySecurityTest` which asserts 401 and 403 responses contain `ApiError` fields `message`, `path`, and `timestamp` and that responses use `application/json` content type.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971f3475e4083289dc434874bdc6704)