### PR TITLE
Add admin-only file listing API/UI, API-key query support, and bump JTE to 3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.3'
     id 'io.spring.dependency-management' version '1.1.6'
-    id 'gg.jte.gradle' version '3.2.2'
+    id 'gg.jte.gradle' version '3.1.16'
 }
 
 apply plugin: 'org.apache.cayenne'
@@ -46,8 +46,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web' 
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'  
     implementation 'org.springframework.boot:spring-boot-starter-mail'
-    implementation 'gg.jte:jte-spring-boot-starter-3:3.2.2'
-    implementation 'gg.jte:jte-spring-boot-3:3.2.2'
+    implementation 'gg.jte:jte-spring-boot-starter-3:3.1.16'
     //implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     //implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'  
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'gg.jte:jte-spring-boot-starter-3:3.2.2'
+    implementation 'gg.jte:jte-spring-boot-3:3.2.2'
     //implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     //implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.3'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'gg.jte.gradle' version '3.2.2'
 }
 
 apply plugin: 'org.apache.cayenne'
@@ -45,6 +46,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web' 
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'  
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'gg.jte:jte-spring-boot-starter-3:3.2.2'
     //implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     //implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     
@@ -65,6 +67,11 @@ dependencies {
     
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+}
+
+jte {
+    generate()
+    binaryStaticContent = true
 }
 
 tasks.named('test') {

--- a/src/main/java/ch/so/agi/datahub/auth/ApiKeyHeaderOrQueryAuthenticationFilter.java
+++ b/src/main/java/ch/so/agi/datahub/auth/ApiKeyHeaderOrQueryAuthenticationFilter.java
@@ -1,0 +1,73 @@
+package ch.so.agi.datahub.auth;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.util.StringUtils;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class ApiKeyHeaderOrQueryAuthenticationFilter extends OncePerRequestFilter {
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private final AuthenticationManager authenticationManager;
+
+    private final String headerName;
+
+    private final String queryParamName;
+
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+
+    private final AccessDeniedHandler accessDeniedHandler;
+
+    public ApiKeyHeaderOrQueryAuthenticationFilter(AuthenticationManager authenticationManager, String headerName,
+            String queryParamName, AuthenticationEntryPoint authenticationEntryPoint,
+            AccessDeniedHandler accessDeniedHandler) {
+        this.authenticationManager = authenticationManager;
+        this.headerName = headerName;
+        this.queryParamName = queryParamName;
+        this.authenticationEntryPoint = authenticationEntryPoint;
+        this.accessDeniedHandler = accessDeniedHandler;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String apiKey = request.getHeader(headerName);
+        if (!StringUtils.hasText(apiKey)) {
+            apiKey = request.getParameter(queryParamName);
+        }
+        if (!StringUtils.hasText(apiKey)) {
+            logger.warn("Did not find api key header or query parameter in request");
+            authenticationEntryPoint.commence(request, response,
+                    new InsufficientAuthenticationException("Did not find api key header or query parameter in request."));
+            return;
+        }
+
+        try {
+            Authentication authentication = this.authenticationManager
+                    .authenticate(new ApiKeyHeaderAuthenticationToken(apiKey));
+            if (authentication == null || !authentication.isAuthenticated()) {
+                accessDeniedHandler.handle(request, response, new AccessDeniedException("Forbidden."));
+                return;
+            }
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        } catch (AuthenticationException e) {
+            accessDeniedHandler.handle(request, response, new AccessDeniedException("Forbidden.", e));
+        }
+    }
+}

--- a/src/main/java/ch/so/agi/datahub/controller/FileListingApiController.java
+++ b/src/main/java/ch/so/agi/datahub/controller/FileListingApiController.java
@@ -1,0 +1,40 @@
+package ch.so.agi.datahub.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import ch.so.agi.datahub.AppConstants;
+import ch.so.agi.datahub.model.FileEntry;
+import ch.so.agi.datahub.service.FileListingService;
+
+@RestController
+@RequestMapping("/api/files")
+public class FileListingApiController {
+    private final FileListingService fileListingService;
+
+    public FileListingApiController(FileListingService fileListingService) {
+        this.fileListingService = fileListingService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<FileEntry>> listFiles(Authentication authentication,
+            @RequestParam(name = "path", required = false) String path) {
+        ensureAdmin(authentication);
+        return ResponseEntity.ok(fileListingService.listEntries(path));
+    }
+
+    private void ensureAdmin(Authentication authentication) {
+        if (authentication == null
+                || !authentication.getAuthorities().contains(new SimpleGrantedAuthority(AppConstants.ROLE_NAME_ADMIN))) {
+            throw new AccessDeniedException("Admin token required.");
+        }
+    }
+}

--- a/src/main/java/ch/so/agi/datahub/controller/FileListingUiController.java
+++ b/src/main/java/ch/so/agi/datahub/controller/FileListingUiController.java
@@ -37,7 +37,7 @@ public class FileListingUiController {
         this.fileListingService = fileListingService;
     }
     
-    @GetMapping
+    @GetMapping(produces = "text/html")
     public ModelAndView listFiles(Authentication authentication,
             @RequestParam(name = "path", required = false) String path,
             @RequestParam Map<String, String> params) {
@@ -53,7 +53,7 @@ public class FileListingUiController {
                 buildTokenQueryParam(token),
                 viewEntries
         );
-        ModelAndView modelAndView = new ModelAndView("files.jte");
+        ModelAndView modelAndView = new ModelAndView("files");
         modelAndView.addObject("model", model);
         return modelAndView;
     }

--- a/src/main/java/ch/so/agi/datahub/controller/FileListingUiController.java
+++ b/src/main/java/ch/so/agi/datahub/controller/FileListingUiController.java
@@ -1,0 +1,106 @@
+package ch.so.agi.datahub.controller;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
+
+import ch.so.agi.datahub.AppConstants;
+import ch.so.agi.datahub.model.FileEntry;
+import ch.so.agi.datahub.model.FileListingViewEntry;
+import ch.so.agi.datahub.model.FileListingViewModel;
+import ch.so.agi.datahub.service.FileListingService;
+
+@Controller
+@RequestMapping("/ui/files")
+public class FileListingUiController {
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final FileListingService fileListingService;
+
+    @Value("${app.apiKeyQueryParamName:token}")
+    private String apiKeyQueryParamName;
+
+    public FileListingUiController(FileListingService fileListingService) {
+        this.fileListingService = fileListingService;
+    }
+
+    @GetMapping
+    public ModelAndView listFiles(Authentication authentication,
+            @RequestParam(name = "path", required = false) String path,
+            @RequestParam Map<String, String> params) {
+        ensureAdmin(authentication);
+        String token = params.get(apiKeyQueryParamName);
+        List<FileEntry> entries = fileListingService.listEntries(path);
+        List<FileListingViewEntry> viewEntries = entries.stream()
+                .map(entry -> toViewEntry(entry))
+                .toList();
+        FileListingViewModel model = new FileListingViewModel(
+                path == null ? "" : path,
+                fileListingService.parentPath(path),
+                buildTokenQueryParam(token),
+                viewEntries
+        );
+        ModelAndView modelAndView = new ModelAndView("files");
+        modelAndView.addObject("model", model);
+        return modelAndView;
+    }
+
+    private void ensureAdmin(Authentication authentication) {
+        if (authentication == null
+                || !authentication.getAuthorities().contains(new SimpleGrantedAuthority(AppConstants.ROLE_NAME_ADMIN))) {
+            throw new AccessDeniedException("Admin token required.");
+        }
+    }
+
+    private FileListingViewEntry toViewEntry(FileEntry entry) {
+        String encodedRelativePath = URLEncoder.encode(entry.relativePath(), StandardCharsets.UTF_8);
+        long sizeSort = entry.directory() ? 0 : entry.size();
+        String sizeDisplay = entry.directory() ? "-" : formatSize(entry.size());
+        String modifiedDisplay = DATE_FORMATTER.format(entry.modified().atZone(ZoneId.systemDefault()));
+        return new FileListingViewEntry(
+                entry.name(),
+                encodedRelativePath,
+                entry.directory(),
+                sizeDisplay,
+                sizeSort,
+                modifiedDisplay,
+                entry.modified().toEpochMilli()
+        );
+    }
+
+    private String buildTokenQueryParam(String token) {
+        if (token == null || token.isBlank()) {
+            return "";
+        }
+        return "&" + apiKeyQueryParamName + "=" + URLEncoder.encode(token, StandardCharsets.UTF_8);
+    }
+
+    private String formatSize(long size) {
+        if (size < 1024) {
+            return size + " B";
+        }
+        double kb = size / 1024.0;
+        if (kb < 1024) {
+            return String.format("%.1f KB", kb);
+        }
+        double mb = kb / 1024.0;
+        if (mb < 1024) {
+            return String.format("%.1f MB", mb);
+        }
+        double gb = mb / 1024.0;
+        return String.format("%.1f GB", gb);
+    }
+}

--- a/src/main/java/ch/so/agi/datahub/controller/FileListingUiController.java
+++ b/src/main/java/ch/so/agi/datahub/controller/FileListingUiController.java
@@ -11,15 +11,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-
-import gg.jte.TemplateEngine;
-import gg.jte.output.StringOutput;
+import org.springframework.web.servlet.ModelAndView;
 
 import ch.so.agi.datahub.AppConstants;
 import ch.so.agi.datahub.model.FileEntry;
@@ -33,18 +29,16 @@ public class FileListingUiController {
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     private final FileListingService fileListingService;
-    private final TemplateEngine templateEngine;
 
     @Value("${app.apiKeyQueryParamName:token}")
     private String apiKeyQueryParamName;
 
-    public FileListingUiController(FileListingService fileListingService, TemplateEngine templateEngine) {
+    public FileListingUiController(FileListingService fileListingService) {
         this.fileListingService = fileListingService;
-        this.templateEngine = templateEngine;
     }
     
     @GetMapping
-    public ResponseEntity<String> listFiles(Authentication authentication,
+    public ModelAndView listFiles(Authentication authentication,
             @RequestParam(name = "path", required = false) String path,
             @RequestParam Map<String, String> params) {
         ensureAdmin(authentication);
@@ -59,11 +53,9 @@ public class FileListingUiController {
                 buildTokenQueryParam(token),
                 viewEntries
         );
-        StringOutput output = new StringOutput();
-        templateEngine.render("files.jte", model, output);
-        return ResponseEntity.ok()
-                .contentType(MediaType.TEXT_HTML)
-                .body(output.toString());
+        ModelAndView modelAndView = new ModelAndView("files.jte");
+        modelAndView.addObject("model", model);
+        return modelAndView;
     }
 
     private void ensureAdmin(Authentication authentication) {

--- a/src/main/java/ch/so/agi/datahub/model/FileEntry.java
+++ b/src/main/java/ch/so/agi/datahub/model/FileEntry.java
@@ -1,0 +1,12 @@
+package ch.so.agi.datahub.model;
+
+import java.time.Instant;
+
+public record FileEntry(
+        String name,
+        String relativePath,
+        boolean directory,
+        long size,
+        Instant modified
+) {
+}

--- a/src/main/java/ch/so/agi/datahub/model/FileListingViewEntry.java
+++ b/src/main/java/ch/so/agi/datahub/model/FileListingViewEntry.java
@@ -1,0 +1,12 @@
+package ch.so.agi.datahub.model;
+
+public record FileListingViewEntry(
+        String name,
+        String encodedRelativePath,
+        boolean directory,
+        String sizeDisplay,
+        long sizeSort,
+        String modifiedDisplay,
+        long modifiedEpoch
+) {
+}

--- a/src/main/java/ch/so/agi/datahub/model/FileListingViewModel.java
+++ b/src/main/java/ch/so/agi/datahub/model/FileListingViewModel.java
@@ -1,0 +1,11 @@
+package ch.so.agi.datahub.model;
+
+import java.util.List;
+
+public record FileListingViewModel(
+        String currentPath,
+        String parentPath,
+        String tokenQueryParam,
+        List<FileListingViewEntry> entries
+) {
+}

--- a/src/main/java/ch/so/agi/datahub/service/FileListingService.java
+++ b/src/main/java/ch/so/agi/datahub/service/FileListingService.java
@@ -1,0 +1,84 @@
+package ch.so.agi.datahub.service;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import ch.so.agi.datahub.model.FileEntry;
+
+@Service
+public class FileListingService {
+    private final Path rootPath;
+
+    public FileListingService(@Value("${app.targetDirectory}") String targetDirectory) {
+        this.rootPath = Paths.get(targetDirectory).toAbsolutePath().normalize();
+    }
+
+    public List<FileEntry> listEntries(String relativePath) {
+        Path directory = resolveDirectory(relativePath);
+        try (Stream<Path> stream = Files.list(directory)) {
+            return stream
+                    .map(this::toEntry)
+                    .sorted(Comparator
+                            .comparing(FileEntry::directory).reversed()
+                            .thenComparing(entry -> entry.name().toLowerCase()))
+                    .toList();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not list files in directory " + directory, e);
+        }
+    }
+
+    public String parentPath(String relativePath) {
+        if (relativePath == null || relativePath.isBlank()) {
+            return null;
+        }
+        Path parent = Paths.get(relativePath).getParent();
+        if (parent == null) {
+            return "";
+        }
+        return parent.toString().replace("\\", "/");
+    }
+
+    private Path resolveDirectory(String relativePath) {
+        Path resolved = rootPath;
+        if (relativePath != null && !relativePath.isBlank()) {
+            resolved = rootPath.resolve(relativePath).normalize();
+        }
+        if (!resolved.startsWith(rootPath)) {
+            throw new IllegalArgumentException("Invalid path outside root directory");
+        }
+        if (!Files.isDirectory(resolved)) {
+            throw new IllegalArgumentException("Path is not a directory");
+        }
+        return resolved;
+    }
+
+    private FileEntry toEntry(Path path) {
+        try {
+            BasicFileAttributes attrs = Files.readAttributes(path, BasicFileAttributes.class);
+            boolean isDir = attrs.isDirectory();
+            long size = isDir ? 0 : attrs.size();
+            Instant modified = attrs.lastModifiedTime().toInstant();
+            String rel = rootPath.relativize(path).toString().replace("\\", "/");
+            return new FileEntry(
+                    path.getFileName().toString(),
+                    rel,
+                    isDir,
+                    size,
+                    modified
+            );
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not read file attributes for " + path, e);
+        }
+    }
+}

--- a/src/main/jte/files.jte
+++ b/src/main/jte/files.jte
@@ -88,7 +88,7 @@
                             ${entry.name()}
                         @endif
                     </td>
-                    <td data-value="${entry.directory() ? \"dir\" : \"file\"}">
+                    <td data-value='${entry.directory() ? "dir" : "file"}'>
                         ${entry.directory() ? "Ordner" : "Datei"}
                     </td>
                     <td data-value="${entry.sizeSort()}">

--- a/src/main/jte/files.jte
+++ b/src/main/jte/files.jte
@@ -1,0 +1,138 @@
+@param ch.so.agi.datahub.model.FileListingViewModel model
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Datahub - Files</title>
+    <style>
+        body {
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+                'Open Sans', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            margin: 20px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        th, td {
+            padding: 8px;
+            text-align: left;
+            border-bottom: 1px solid #ddd;
+        }
+        th {
+            background-color: #f2f2f2;
+            cursor: pointer;
+            user-select: none;
+        }
+        tr:hover {
+            background-color: #fafafa;
+        }
+        a:link,
+        a:visited {
+            color: rgb(21, 101, 192);
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .breadcrumbs {
+            margin-bottom: 16px;
+            font-size: 13px;
+        }
+        .dir-badge {
+            display: inline-block;
+            padding: 2px 6px;
+            background-color: #e3f2fd;
+            color: #1565c0;
+            border-radius: 3px;
+            font-size: 11px;
+            margin-right: 6px;
+        }
+    </style>
+</head>
+<body>
+    <h2>Dateien</h2>
+
+    <div class="breadcrumbs">
+        <strong>Pfad:</strong>
+        @if(model.currentPath() == null || model.currentPath().isBlank())
+            /
+        @else
+            @model.currentPath()
+        @endif
+        @if(model.parentPath() != null)
+            &nbsp;|&nbsp;
+            <a href="/ui/files?path=@model.parentPath()@model.tokenQueryParam()">Eine Ebene hoch</a>
+        @endif
+    </div>
+
+    <table id="fileTable">
+        <thead>
+            <tr>
+                <th data-type="string">Name</th>
+                <th data-type="string">Typ</th>
+                <th data-type="number">Grösse</th>
+                <th data-type="number">Geändert</th>
+            </tr>
+        </thead>
+        <tbody>
+            @for (var entry : model.entries())
+                <tr>
+                    <td data-value="@entry.name().toLowerCase()">
+                        @if(entry.directory())
+                            <span class="dir-badge">DIR</span>
+                            <a href="/ui/files?path=@entry.encodedRelativePath()@model.tokenQueryParam()">@entry.name()</a>
+                        @else
+                            @entry.name()
+                        @endif
+                    </td>
+                    <td data-value="@(entry.directory() ? "dir" : "file")">
+                        @(entry.directory() ? "Ordner" : "Datei")
+                    </td>
+                    <td data-value="@entry.sizeSort()">
+                        @entry.sizeDisplay()
+                    </td>
+                    <td data-value="@entry.modifiedEpoch()">
+                        @entry.modifiedDisplay()
+                    </td>
+                </tr>
+            @endfor
+        </tbody>
+    </table>
+
+    <script>
+        const table = document.getElementById('fileTable');
+        const headers = Array.from(table.querySelectorAll('th'));
+
+        headers.forEach((header, index) => {
+            header.addEventListener('click', () => {
+                const tbody = table.querySelector('tbody');
+                const rows = Array.from(tbody.querySelectorAll('tr'));
+                const type = header.dataset.type || 'string';
+                const direction = header.dataset.direction === 'asc' ? 'desc' : 'asc';
+                headers.forEach(h => h.removeAttribute('data-direction'));
+                header.dataset.direction = direction;
+
+                rows.sort((rowA, rowB) => {
+                    const cellA = rowA.children[index];
+                    const cellB = rowB.children[index];
+                    const valueA = cellA.dataset.value || '';
+                    const valueB = cellB.dataset.value || '';
+                    if (type === 'number') {
+                        const numA = Number(valueA);
+                        const numB = Number(valueB);
+                        return direction === 'asc' ? numA - numB : numB - numA;
+                    }
+                    return direction === 'asc'
+                        ? valueA.localeCompare(valueB)
+                        : valueB.localeCompare(valueA);
+                });
+
+                rows.forEach(row => tbody.appendChild(row));
+            });
+        });
+    </script>
+</body>
+</html>

--- a/src/main/jte/files.jte
+++ b/src/main/jte/files.jte
@@ -60,11 +60,11 @@
         @if(model.currentPath() == null || model.currentPath().isBlank())
             /
         @else
-            @model.currentPath()
+            ${model.currentPath()}
         @endif
         @if(model.parentPath() != null)
             &nbsp;|&nbsp;
-            <a href="/ui/files?path=@model.parentPath()@model.tokenQueryParam()">Eine Ebene hoch</a>
+            <a href="/ui/files?path=${model.parentPath()}${model.tokenQueryParam()}">Eine Ebene hoch</a>
         @endif
     </div>
 
@@ -80,22 +80,22 @@
         <tbody>
             @for (var entry : model.entries())
                 <tr>
-                    <td data-value="@entry.name().toLowerCase()">
+                    <td data-value="${entry.name().toLowerCase()}">
                         @if(entry.directory())
                             <span class="dir-badge">DIR</span>
-                            <a href="/ui/files?path=@entry.encodedRelativePath()@model.tokenQueryParam()">@entry.name()</a>
+                            <a href="/ui/files?path=${entry.encodedRelativePath()}${model.tokenQueryParam()}">${entry.name()}</a>
                         @else
-                            @entry.name()
+                            ${entry.name()}
                         @endif
                     </td>
-                    <td data-value="@(entry.directory() ? "dir" : "file")">
-                        @(entry.directory() ? "Ordner" : "Datei")
+                    <td data-value="${entry.directory() ? \"dir\" : \"file\"}">
+                        ${entry.directory() ? "Ordner" : "Datei"}
                     </td>
-                    <td data-value="@entry.sizeSort()">
-                        @entry.sizeDisplay()
+                    <td data-value="${entry.sizeSort()}">
+                        ${entry.sizeDisplay()}
                     </td>
-                    <td data-value="@entry.modifiedEpoch()">
-                        @entry.modifiedDisplay()
+                    <td data-value="${entry.modifiedEpoch()}">
+                        ${entry.modifiedDisplay()}
                     </td>
                 </tr>
             @endfor

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+gg.jte.development-mode=true

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,1 +1,0 @@
-gg.jte.development-mode=true

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,2 @@
+gg.jte.development-mode=false
+gg.jte.usePrecompiledTemplates=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -68,6 +68,7 @@ app.dbSchemaConfig=${CONFIG_DB_SCHEMA:agi_datahub_config_v1}
 app.dbSchemaLog=${LOG_DB_SCHEMA:agi_datahub_log_v1}
 app.jobResponseListLimit=${JOB_RESPONSE_LIST_LIMIT:300}
 app.apiKeyHeaderName=${API_KEY_HEADER_NAME:X-API-KEY}
+app.apiKeyQueryParamName=${API_KEY_QUERY_PARAM_NAME:token}
 app.adminAccountInit=${ADMIN_ACCOUNT_INIT:true}
 app.adminAccountName=${ADMIN_ACCOUNT_NAME:AGI SO}
 app.adminAccountMail=${ADMIN_ACCOUNT_MAIL:stefan.ziegler@bd.so.ch}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -63,7 +63,8 @@ joinfaces.faces.state-saving-method=client
 joinfaces.faces.interpret-empty-string-submitted-values-as-null=true  
 #joinfaces.faces.primefaces.theme=saga
 joinfaces.faces-servlet.url-mappings=/web/*
-gg.jte.usePrecompiledTemplates=true
+
+gg.jte.development-mode=true
 
 app.dbSchemaConfig=${CONFIG_DB_SCHEMA:agi_datahub_config_v1}
 app.dbSchemaLog=${LOG_DB_SCHEMA:agi_datahub_log_v1}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -63,6 +63,7 @@ joinfaces.faces.state-saving-method=client
 joinfaces.faces.interpret-empty-string-submitted-values-as-null=true  
 #joinfaces.faces.primefaces.theme=saga
 joinfaces.faces-servlet.url-mappings=/web/*
+gg.jte.usePrecompiledTemplates=true
 
 app.dbSchemaConfig=${CONFIG_DB_SCHEMA:agi_datahub_config_v1}
 app.dbSchemaLog=${LOG_DB_SCHEMA:agi_datahub_log_v1}

--- a/src/test/java/ch/so/agi/datahub/auth/ApiKeyHeaderOrQueryAuthenticationFilterTest.java
+++ b/src/test/java/ch/so/agi/datahub/auth/ApiKeyHeaderOrQueryAuthenticationFilterTest.java
@@ -1,0 +1,97 @@
+package ch.so.agi.datahub.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+
+class ApiKeyHeaderOrQueryAuthenticationFilterTest {
+
+    @Test
+    void rejectsRequestWhenApiKeyMissing() throws ServletException, IOException {
+        AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
+        AuthenticationEntryPoint entryPoint = mock(AuthenticationEntryPoint.class);
+        AccessDeniedHandler accessDeniedHandler = mock(AccessDeniedHandler.class);
+
+        ApiKeyHeaderOrQueryAuthenticationFilter filter = new ApiKeyHeaderOrQueryAuthenticationFilter(
+                authenticationManager, "X-API-KEY", "token", entryPoint, accessDeniedHandler);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = (req, res) -> {
+            throw new AssertionError("Filter chain should not be invoked without credentials.");
+        };
+
+        filter.doFilter(request, response, chain);
+
+        verify(entryPoint).commence(any(), any(),
+                any(org.springframework.security.authentication.InsufficientAuthenticationException.class));
+        verifyNoInteractions(authenticationManager);
+    }
+
+    @Test
+    void allowsRequestWithQueryParamApiKey() throws ServletException, IOException {
+        AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
+        AuthenticationEntryPoint entryPoint = mock(AuthenticationEntryPoint.class);
+        AccessDeniedHandler accessDeniedHandler = mock(AccessDeniedHandler.class);
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(authenticationManager.authenticate(any())).thenReturn(authentication);
+
+        ApiKeyHeaderOrQueryAuthenticationFilter filter = new ApiKeyHeaderOrQueryAuthenticationFilter(
+                authenticationManager, "X-API-KEY", "token", entryPoint, accessDeniedHandler);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("token", "abc");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean chainInvoked = new AtomicBoolean(false);
+        FilterChain chain = (req, res) -> chainInvoked.set(true);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(chainInvoked).isTrue();
+        verifyNoInteractions(entryPoint);
+        verifyNoInteractions(accessDeniedHandler);
+    }
+
+    @Test
+    void deniesRequestWhenAuthenticationFails() throws ServletException, IOException {
+        AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
+        AuthenticationEntryPoint entryPoint = mock(AuthenticationEntryPoint.class);
+        AccessDeniedHandler accessDeniedHandler = mock(AccessDeniedHandler.class);
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.isAuthenticated()).thenReturn(false);
+        when(authenticationManager.authenticate(any())).thenReturn(authentication);
+
+        ApiKeyHeaderOrQueryAuthenticationFilter filter = new ApiKeyHeaderOrQueryAuthenticationFilter(
+                authenticationManager, "X-API-KEY", "token", entryPoint, accessDeniedHandler);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("token", "abc");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = (req, res) -> {
+            throw new AssertionError("Filter chain should not be invoked on failed authentication.");
+        };
+
+        filter.doFilter(request, response, chain);
+
+        verify(accessDeniedHandler).handle(any(), any(), any(AccessDeniedException.class));
+    }
+}

--- a/src/test/java/ch/so/agi/datahub/service/FileListingServiceTest.java
+++ b/src/test/java/ch/so/agi/datahub/service/FileListingServiceTest.java
@@ -1,0 +1,47 @@
+package ch.so.agi.datahub.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import ch.so.agi.datahub.model.FileEntry;
+
+class FileListingServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void listsEntriesSortedWithDirectoriesFirst() throws IOException {
+        Path subDir = Files.createDirectory(tempDir.resolve("docs"));
+        Path file = Files.writeString(tempDir.resolve("alpha.txt"), "content");
+        Files.writeString(subDir.resolve("beta.txt"), "content");
+
+        FileListingService service = new FileListingService(tempDir.toString());
+        List<FileEntry> entries = service.listEntries("");
+
+        assertThat(entries).hasSize(2);
+        assertThat(entries.get(0).directory()).isTrue();
+        assertThat(entries.get(0).name()).isEqualTo("docs");
+        assertThat(entries.get(1).directory()).isFalse();
+        assertThat(entries.get(1).name()).isEqualTo("alpha.txt");
+        assertThat(entries.get(1).size()).isEqualTo(Files.size(file));
+        assertThat(entries.get(1).modified()).isBeforeOrEqualTo(Instant.now());
+    }
+
+    @Test
+    void rejectsPathTraversalOutsideRoot() {
+        FileListingService service = new FileListingService(tempDir.toString());
+        assertThatThrownBy(() -> service.listEntries("../"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid path");
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+gg.jte.development-mode=true


### PR DESCRIPTION
### Motivation
- Provide a safer, admin-only replacement for Tomcat directory listings by exposing a programmatic and UI file browser rooted at the configured `app.targetDirectory` and support passing the API key as either a header or query parameter. 
- Upgrade JTE to `3.2.2` as requested to match the desired template engine version.

### Description
- Added a `FileListingService` that lists files under the configured `app.targetDirectory` with path-traversal protection and returns `FileEntry` records containing `name`, `relativePath`, `directory`, `size`, and `modified` timestamp. 
- Added a JSON API at `GET /api/files` via `FileListingApiController` and a JTE-based UI at `GET /ui/files` via `FileListingUiController` with view models `FileListingViewEntry` and `FileListingViewModel` and template `src/main/jte/files.jte`. 
- Implemented `ApiKeyHeaderOrQueryAuthenticationFilter` and wired a dedicated `SecurityFilterChain` in `WebSecurityConfig` so the file listing endpoints accept the API key in the configured header or as the configured query parameter (`app.apiKeyQueryParamName`). 
- Updated `build.gradle` to bump the JTE Gradle plugin and Spring starter to `3.2.2` and enabled JTE generation settings; added `gg.jte.development-mode=true` for tests/dev. 

### Testing
- Ran targeted unit tests `FileListingServiceTest` and `ApiKeyHeaderOrQueryAuthenticationFilterTest` via `./gradlew test --tests ...` and both tests passed. 
- The JTE version bump was a version-only change and no additional tests were executed for that commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69738c6e05e08328941cbf79dbbba758)