### PR TITLE
Make file listing entries downloadable

### DIFF
--- a/src/main/java/ch/so/agi/datahub/service/FileListingService.java
+++ b/src/main/java/ch/so/agi/datahub/service/FileListingService.java
@@ -49,6 +49,20 @@ public class FileListingService {
         return parent.toString().replace("\\", "/");
     }
 
+    public Path resolveFile(String relativePath) {
+        if (relativePath == null || relativePath.isBlank()) {
+            throw new IllegalArgumentException("Path is required");
+        }
+        Path resolved = rootPath.resolve(relativePath).normalize();
+        if (!resolved.startsWith(rootPath)) {
+            throw new IllegalArgumentException("Invalid path outside root directory");
+        }
+        if (!Files.isRegularFile(resolved)) {
+            throw new IllegalArgumentException("Path is not a file");
+        }
+        return resolved;
+    }
+
     private Path resolveDirectory(String relativePath) {
         Path resolved = rootPath;
         if (relativePath != null && !relativePath.isBlank()) {

--- a/src/main/jte/files.jte
+++ b/src/main/jte/files.jte
@@ -85,7 +85,7 @@
                             <span class="dir-badge">DIR</span>
                             <a href="/ui/files?path=${entry.encodedRelativePath()}${model.tokenQueryParam()}">${entry.name()}</a>
                         @else
-                            ${entry.name()}
+                            <a href="/ui/files/download?path=${entry.encodedRelativePath()}${model.tokenQueryParam()}">${entry.name()}</a>
                         @endif
                     </td>
                     <td data-value='${entry.directory() ? "dir" : "file"}'>

--- a/src/test/java/ch/so/agi/datahub/controller/FileListingUiControllerTest.java
+++ b/src/test/java/ch/so/agi/datahub/controller/FileListingUiControllerTest.java
@@ -1,0 +1,49 @@
+package ch.so.agi.datahub.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.core.io.Resource;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import ch.so.agi.datahub.AppConstants;
+import ch.so.agi.datahub.service.FileListingService;
+
+class FileListingUiControllerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void downloadFileReturnsAttachment() throws Exception {
+        FileListingService fileListingService = mock(FileListingService.class);
+        FileListingUiController controller = new FileListingUiController(fileListingService);
+
+        Authentication authentication = mock(Authentication.class);
+        doReturn(List.of(new SimpleGrantedAuthority(AppConstants.ROLE_NAME_ADMIN)))
+                .when(authentication)
+                .getAuthorities();
+
+        Path filePath = Files.createTempFile(tempDir, "sample", ".txt");
+        Files.writeString(filePath, "content");
+        doReturn(filePath).when(fileListingService).resolveFile("sample.txt");
+
+        ResponseEntity<Resource> response = controller.downloadFile(authentication, "sample.txt");
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION))
+                .contains("attachment")
+                .contains(filePath.getFileName().toString());
+        assertThat(response.getBody()).isNotNull();
+    }
+}


### PR DESCRIPTION
### Motivation
- Allow users to download files directly from the file listing UI by clicking a file name. 
- Ensure downloads are served from the configured target directory and keep the existing admin-only access control. 

### Description
- Added `resolveFile(String)` to `FileListingService` to validate and resolve a requested file path inside the configured root. 
- Added a `GET /ui/files/download` endpoint in `FileListingUiController` that returns the file as an attachment with a detected `Content-Type` (falls back to `application/octet-stream`) and a `Content-Disposition` header. 
- Updated the file listing template `files.jte` so file names link to `/ui/files/download?path=...` (preserving the API token query param when present). 
- Added `FileListingUiControllerTest` to assert the download response contains an attachment `Content-Disposition` and a non-null body. 

### Testing
- Ran `./gradlew test` and all unit tests passed. 
- Ran `./gradlew check` and the build checks passed. 
- Attempted `./gradlew bootRun` which failed to start the embedded server due to a missing resource directory on the host (`/Users/stefan/tmp`), so a full runtime manual verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b8593e308328b2e500d9de7c484d)