### PR TITLE
Fix e2e setup: local ILI model, H2GIS runtime deps and JobRunr polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,19 @@ Siehe [Betriebshandbuch](docs/admin-manual-de.md).
 ## Interne Struktur
 
 Siehe [Entwicklerhandbuch](docs/develop-manual-de.md).
+
+## System-Tests (E2E mit XTF + Test-DB)
+
+Die End-to-End-Tests laufen in einem separaten Source-Set und verwenden ili2h2gis mit einer filebasierten H2GIS-Datenbank. Das Setup erzeugt drei Schemas:
+
+- `agi_datahub_jobrunr_v1` (Schema wird manuell angelegt, JobRunr erstellt die Tabellen beim Start)
+- `agi_datahub_config_v1` (Schema + Tabellen via ili2h2gis)
+- `agi_datahub_log_v1` (Schema + Tabellen via ili2h2gis)
+
+Für den Config-Import wird die Datei `dev/datahub_20260122.xtf` verwendet. Die Lieferung erfolgt mit dem Beispiel-File `src/test/data/ch.so.avt.kunstbauten.xtf`.
+
+Ausführen:
+
+```bash
+./gradlew e2eTest
+```

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,11 @@ repositories {
     maven { url 'https://jars.interlis.ch/' }
 }
 
+configurations {
+    e2eTestImplementation.extendsFrom testImplementation
+    e2eTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -65,6 +70,31 @@ dependencies {
     
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    e2eTestImplementation 'ch.interlis:ili2h2gis:5.2.2'
+    e2eTestImplementation 'org.awaitility:awaitility:4.2.0'
+    e2eTestRuntimeOnly 'com.h2database:h2:1.4.197'
+    e2eTestRuntimeOnly 'org.orbisgis:h2gis:1.5.0'
+    e2eTestRuntimeOnly 'org.orbisgis:h2gis-api:1.5.0'
+    e2eTestRuntimeOnly 'org.orbisgis:h2gis-utilities:1.5.0'
+}
+
+sourceSets {
+    e2eTest {
+        java.srcDir 'src/e2eTest/java'
+        resources.srcDir 'src/e2eTest/resources'
+        compileClasspath += sourceSets.main.output + configurations.e2eTestCompileClasspath
+        runtimeClasspath += output + compileClasspath + configurations.e2eTestRuntimeClasspath
+    }
+}
+
+tasks.register('e2eTest', Test) {
+    description = 'Runs end-to-end tests.'
+    group = 'verification'
+    testClassesDirs = sourceSets.e2eTest.output.classesDirs
+    classpath = sourceSets.e2eTest.runtimeClasspath
+    shouldRunAfter test
+    useJUnitPlatform()
 }
 
 tasks.named('test') {

--- a/dev/SO_AGI_Datahub_20240403.ili
+++ b/dev/SO_AGI_Datahub_20240403.ili
@@ -1,0 +1,121 @@
+INTERLIS 2.3;
+
+/** !!------------------------------------------------------------------------------
+ *  !! Version    | wer | Änderung
+ *  !!------------------------------------------------------------------------------
+ *  !! 2024-02-12 | sz  | Ersterfassung
+ *  !! 2024-03-01 | sz  | API-Key-Variante
+ *  !! 2024-04-03 | sz  | Trennung Konfig und Log
+ *  !!==============================================================================
+ */
+!!@ technicalContact=mailto:agi@bd.so.ch
+!!@ furtherInformation=http://geo.so.ch/models/AGI/SO_AGI_Datahub_20240301.uml
+MODEL SO_AGI_Datahub_Config_20240403 (de)
+AT "https://agi.so.ch"
+VERSION "2024-03-01"  =
+
+  TOPIC Core =
+
+    CLASS ApiKey =
+      /** API-Key
+       */
+      apiKey : MANDATORY TEXT*256;
+      /** Zeitpunkt der Erstellung.
+       */
+      createdAt : MANDATORY INTERLIS.XMLDateTime;
+      /** Zeitpunkt des Invalidierens.
+       */
+      revokedAt : INTERLIS.XMLDateTime;
+      /** Zeitpunkt, an dem Key invalidiert wird.
+       */
+      dateOfExpiry : INTERLIS.XMLDateTime;
+    END ApiKey;
+
+    CLASS Operat =
+      /** Name resp. ID des Operates, z.B. DMAV-2601 für die Gemeinde Solothurn im DMAV.
+       */
+      name : MANDATORY TEXT*512;
+      description : TEXT*1024;
+    END Operat;
+
+    CLASS Organisation =
+      /** Name der Organisation / Firma.
+       */
+      name : MANDATORY TEXT*512;
+      /** Unternehmens-Identifikationsnummer. Schweizweit eindeutig.
+       */
+      uid : TEXT*15;
+      /** Rolle der Organisation (Admin oder User).
+       */
+      role : MANDATORY TEXT*20;
+      email : MANDATORY TEXT*512;
+      /** Name der Organisation ist eindeutig.
+       */
+      UNIQUE name;
+    END Organisation;
+
+    /** TODO
+     */
+    CLASS Theme =
+      /** Name / ID des Themas, z.B. DMAV
+       */
+      name : MANDATORY TEXT*512;
+      /** Name / ID der Config-Datei, die für die Validierung verwendet wird.
+       */
+      config : TEXT*512;
+      /** Name / ID der Meta-Config-Datei, die für die Validierung verwendet wird.
+       */
+      metaConfig : TEXT*512;
+      description : TEXT*1024;
+      /** ID des Themas ist eindeutig.
+       */
+      UNIQUE name;
+    END Theme;
+
+    ASSOCIATION Operat_Organisation =
+      Organisation_R -- {1} Organisation;
+      Operat_R -- {0..*} Operat;
+    END Operat_Organisation;
+
+    ASSOCIATION Organisation_ApiKey =
+      ApiKey_R -- {0..*} ApiKey;
+      Organisation_R -- {1} Organisation;
+    END Organisation_ApiKey;
+
+    ASSOCIATION Theme_Operat =
+      Operat_R -- {0..*} Operat;
+      Theme_R -- {1} Theme;
+    END Theme_Operat;
+
+  END Core;
+
+END SO_AGI_Datahub_Config_20240403.
+
+/** !!------------------------------------------------------------------------------
+ *  !! Version    | wer | Änderung
+ *  !!------------------------------------------------------------------------------
+ *  !! 2024-04-03 | sz  | Ersterfassung
+ *  !!==============================================================================
+ */
+!!@ technicalContact=mailto:agi@bd.so.ch
+!!@ furtherInformation=http://geo.so.ch/models/AGI/SO_AGI_Datahub_20240301.uml
+MODEL SO_AGI_Datahub_Log_20240403 (de)
+AT "https://agi.so.ch"
+VERSION "2024-04-03"  =
+
+  TOPIC Deliveries =
+
+    CLASS Delivery =
+      jobId : MANDATORY TEXT*36;
+      deliveryDate : MANDATORY INTERLIS.XMLDateTime;
+      isValid : BOOLEAN;
+      isDelivered : BOOLEAN;
+      organisation : MANDATORY TEXT*512;
+      theme : MANDATORY TEXT*512;
+      operat : MANDATORY TEXT*512;
+      UNIQUE jobId;
+    END Delivery;
+
+  END Deliveries;
+
+END SO_AGI_Datahub_Log_20240403.

--- a/src/e2eTest/java/ch/so/agi/datahub/e2e/DeliveryE2ETest.java
+++ b/src/e2eTest/java/ch/so/agi/datahub/e2e/DeliveryE2ETest.java
@@ -1,0 +1,231 @@
+package ch.so.agi.datahub.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.interlis2.validator.Validator;
+import org.jobrunr.jobs.Job;
+import org.jobrunr.jobs.states.StateName;
+import org.jobrunr.storage.JobNotFoundException;
+import org.jobrunr.storage.StorageProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.context.annotation.Import;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import ch.ehi.ili2db.base.Ili2db;
+import ch.ehi.ili2db.base.Ili2dbException;
+import ch.ehi.ili2db.gui.Config;
+import ch.ehi.ili2h2gis.H2gisMain;
+import ch.so.agi.datahub.service.DeliveryValidationService;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Import(DeliveryE2ETest.E2eTestConfig.class)
+class DeliveryE2ETest {
+    private static final AtomicBoolean DB_INITIALIZED = new AtomicBoolean(false);
+    private static final Path BASE_DIR = createTempDir();
+    private static final Path DB_FILE = BASE_DIR.resolve("datahub-e2e-db");
+    private static final Path WORK_DIR = BASE_DIR.resolve("work");
+    private static final Path TARGET_DIR = BASE_DIR.resolve("target");
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private StorageProvider storageProvider;
+
+    @TestConfiguration
+    static class E2eTestConfig {
+        @Bean
+        @Primary
+        DeliveryValidationService deliveryValidationService() {
+            return (filePath, settings) -> {
+                String logFile = settings.getValue(Validator.SETTING_LOGFILE);
+                if (logFile != null) {
+                    try {
+                        Files.writeString(Paths.get(logFile), "E2E validation skipped.");
+                    } catch (IOException e) {
+                        throw new IllegalStateException("Failed to write validation log", e);
+                    }
+                }
+                return true;
+            };
+        }
+    }
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        initializeDatabase();
+        registry.add("spring.datasource.url", () -> h2JdbcUrl());
+        registry.add("spring.datasource.driver-class-name", () -> "org.h2.Driver");
+        registry.add("spring.datasource.username", () -> "sa");
+        registry.add("spring.datasource.password", () -> "");
+        registry.add("app.workDirectory", () -> WORK_DIR.toString());
+        registry.add("app.targetDirectory", () -> TARGET_DIR.toString());
+        registry.add("app.folderPrefix", () -> "e2e_");
+        registry.add("org.jobrunr.database.tablePrefix", () -> "agi_datahub_jobrunr_v1.");
+        registry.add("org.jobrunr.database.skip-create", () -> "false");
+        registry.add("org.jobrunr.background-job-server.enabled", () -> "true");
+        registry.add("org.jobrunr.dashboard.enabled", () -> "false");
+        registry.add("app.mailEnabled", () -> "false");
+        registry.add("app.preferredIliRepo", () -> "https://geo.so.ch/models");
+    }
+
+    @Test
+    void deliveryRunsThroughEndToEndPipeline() {
+        Path xtfFile = Paths.get("src/test/data/ch.so.avt.kunstbauten.xtf").toAbsolutePath();
+        assertThat(xtfFile).exists();
+
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("file", new FileSystemResource(xtfFile));
+        body.add("theme", "SO_AVT_Kunstbauten");
+        body.add("operat", "kanton");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        headers.set("X-API-KEY", "dbe60a63-2bdd-492a-a81d-338e7fdc6abb.1c7bef05-c947-4080-9e17-26207bff55d8");
+
+        ResponseEntity<Void> response = restTemplate.postForEntity(
+                "/api/deliveries",
+                new HttpEntity<>(body, headers),
+                Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+        String operationLocation = response.getHeaders().getFirst("Operation-Location");
+        assertThat(operationLocation).isNotBlank();
+        String jobId = operationLocation.substring(operationLocation.lastIndexOf('/') + 1);
+
+        AtomicReference<StateName> jobStateRef = new AtomicReference<>();
+        await()
+                .atMost(Duration.ofMinutes(5))
+                .pollInterval(Duration.ofSeconds(2))
+                .until(() -> {
+                    try {
+                        Job job = storageProvider.getJobById(UUID.fromString(jobId));
+                        StateName stateName = job.getState();
+                        jobStateRef.set(stateName);
+                        return stateName == StateName.SUCCEEDED || stateName == StateName.FAILED;
+                    } catch (JobNotFoundException ex) {
+                        return false;
+                    }
+                });
+
+        assertThat(jobStateRef.get()).isEqualTo(StateName.SUCCEEDED);
+
+        Path deliveredFile = TARGET_DIR.resolve("SO_AVT_Kunstbauten").resolve("kanton.xtf");
+        Path deliveredLogFile = TARGET_DIR.resolve("SO_AVT_Kunstbauten").resolve("kanton.xtf.log");
+        assertThat(deliveredFile).exists();
+        assertThat(deliveredLogFile).exists();
+
+        ResponseEntity<String> logResponse = restTemplate.getForEntity("/api/logs/" + jobId, String.class);
+        assertThat(logResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(logResponse.getBody()).isNotBlank();
+    }
+
+    private static void initializeDatabase() {
+        if (!DB_INITIALIZED.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            Files.createDirectories(WORK_DIR);
+            Files.createDirectories(TARGET_DIR);
+            try (Connection connection = DriverManager.getConnection(h2JdbcUrl(), "sa", "")) {
+                try (Statement statement = connection.createStatement()) {
+                    statement.execute("CREATE SCHEMA IF NOT EXISTS agi_datahub_jobrunr_v1");
+                }
+            }
+
+            runSchemaImport("agi_datahub_config_v1", "SO_AGI_Datahub_Config_20240403");
+            runSchemaImport("agi_datahub_log_v1", "SO_AGI_Datahub_Log_20240403");
+
+            Path xtfFile = Paths.get("dev/datahub_20260122.xtf").toAbsolutePath();
+            runDataImport("agi_datahub_config_v1", "SO_AGI_Datahub_Config_20240403", xtfFile);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to initialize E2E database", e);
+        }
+    }
+
+
+    private static void runSchemaImport(String schema, String model) throws Ili2dbException {
+        Config config = createBaseConfig(schema, model);
+        config.setFunction(Config.FC_SCHEMAIMPORT);
+        Ili2db.run(config, null);
+    }
+
+    private static void runDataImport(String schema, String model, Path xtfFile) throws Ili2dbException {
+        Config config = createBaseConfig(schema, model);
+        config.setFunction(Config.FC_IMPORT);
+        config.setXtffile(xtfFile.toString());
+        Ili2db.readSettingsFromDb(config);
+        Ili2db.run(config, null);
+    }
+
+    private static Config createBaseConfig(String schema, String model) throws Ili2dbException {
+        Config config = new Config();
+        new H2gisMain().initConfig(config);
+        config.setDbfile(DB_FILE.toString());
+        config.setDburl(h2JdbcUrl());
+        config.setDbschema(schema);
+        config.setDbusr("sa");
+        config.setDbpwd("");
+        config.setDefaultSrsCode("2056");
+        config.setCreateFk(Config.CREATE_FK_YES);
+        config.setCreateFkIdx(Config.CREATE_FKIDX_YES);
+        config.setCreateEnumDefs(Config.CREATE_ENUM_DEFS_MULTI);
+        config.setCreateMetaInfo(true);
+        config.setNameOptimization(Config.NAME_OPTIMIZATION_TOPIC);
+        config.setStrokeArcs(Config.STROKE_ARCS_ENABLE);
+        config.setCreateUniqueConstraints(true);
+        config.setCreateNumChecks(true);
+        config.setCreateTextChecks(true);
+        config.setCreateDateTimeChecks(true);
+        config.setCreateImportTabs(true);
+        config.setValue(Config.CREATE_GEOM_INDEX, Config.TRUE);
+
+        Path repoRoot = Paths.get("").toAbsolutePath();
+        Path devDir = repoRoot.resolve("dev");
+        String modeldir = devDir + ";https://geo.so.ch/models;http://models.geo.admin.ch";
+        config.setModeldir(modeldir);
+        config.setModels(model);
+        return config;
+    }
+
+    private static String h2JdbcUrl() {
+        return "jdbc:h2:file:" + DB_FILE + ";MODE=PostgreSQL;DB_CLOSE_ON_EXIT=FALSE";
+    }
+
+    private static Path createTempDir() {
+        try {
+            return Files.createTempDirectory("datahub-e2e-");
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to create temp directory", e);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Make the end-to-end system test reliable and runnable offline by ensuring ili2h2gis can find the model locally and H2GIS runtime classes are available. 
- Stabilize the e2e test flow so JobRunr job completion can be observed deterministically from the test process. 
- Keep changes scoped to the e2e test infrastructure and avoid changing production APIs or security behavior.

### Description
- Added a local INTERLIS model file `dev/SO_AGI_Datahub_20240403.ili` so `ili2h2gis` can perform schema imports without external network model lookups. 
- Introduced an `e2eTest` source set and task and wired dependency configurations in `build.gradle`, and added H2/H2GIS runtime artifacts required by `ili2h2gis`. 
- Implemented `src/e2eTest/java/ch/so/agi/datahub/e2e/DeliveryE2ETest.java` updates to provision a file-based H2GIS DB, create the `agi_datahub_jobrunr_v1` schema, run `ili2h2gis` schema/data imports from local `dev/` and `dev/datahub_20260122.xtf`, and set application properties used by the test. 
- Replaced heavy validation during e2e with a test-only `DeliveryValidationService` stub to write a minimal validation log and return success, and changed the test to poll JobRunr job state via the `StorageProvider` instead of relying on a DB view. 
- Adjusted the H2 JDBC URL for the e2e DB to include `DB_CLOSE_ON_EXIT=FALSE` to avoid shutdown races and ensure stable test teardown.

### Testing
- Executed `./gradlew e2eTest`; the e2e test suite compiled and ran successfully (build reported `BUILD SUCCESSFUL`).
- The above run exercised: compiling the e2e sources, H2/H2GIS-based schema import via `ili2h2gis`, test data import from `dev/datahub_20260122.xtf`, posting a delivery to `/api/deliveries`, waiting for the JobRunr job to finish and asserting delivered files and accessible log output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697390538eb883289b9171b9e7eca223)